### PR TITLE
chore(gateway): add dev CORS fallback for local Vite frontend

### DIFF
--- a/api-gateway/src/main/resources/application-dev.yml
+++ b/api-gateway/src/main/resources/application-dev.yml
@@ -12,3 +12,12 @@ auth:
     issuer: novaplay-auth
     audience: novaplay
     kid: v1
+
+# Local-dev fallback for CORS. Production values come from cloud-config.
+# Override in cloud-config/application.yml when adding new frontend origins.
+application:
+  cors:
+    allowed-origins:
+      - http://localhost:5173
+      - http://localhost:3000
+      - http://127.0.0.1:5173


### PR DESCRIPTION
## Summary

Đi kèm PR FE (`81quanghuy/novaplay_fe#claude/merge-login-logic-1l6po`) tích hợp login JWT mới với backend.

Phát hiện CORS đã được handle đúng ở `api-gateway/configs/SecurityConfig.java` — đọc `application.cors.allowed-origins` từ Spring Cloud Config (`81quanghuy/cloud_config_NovaPlay`). Tuy nhiên khi chạy local mà chưa kịp cập nhật cloud-config, gateway sẽ thiếu property và CORS fail.

PR này **chỉ thêm fallback default** trong profile `dev` để dev local hoạt động ngay với Vite (`5173`) và CRA (`3000`) mà không phụ thuộc cloud-config.

**Không thay đổi:**
- Logic auth-service / security
- CORS policy production (vẫn lấy từ cloud-config khi deploy)
- Endpoints / DTOs

## Files changed

- `api-gateway/src/main/resources/application-dev.yml`
  - Thêm block:
    ```yaml
    application:
      cors:
        allowed-origins:
          - http://localhost:5173
          - http://localhost:3000
          - http://127.0.0.1:5173
    ```
  - Kèm comment giải thích đây là fallback dev; production vẫn override từ cloud-config.

## Test plan

- [ ] Chạy gateway profile `dev` không cần cloud-config: `./mvnw spring-boot:run -pl api-gateway -Dspring-boot.run.profiles=dev`
- [ ] Từ FE Vite (`http://localhost:5173`), gọi `POST /api/v1/auth/login` → response có header `Access-Control-Allow-Origin: http://localhost:5173`
- [ ] Pre-flight `OPTIONS` cho `/api/v1/auth/login` trả 200 với `Access-Control-Allow-Methods` + `Access-Control-Allow-Headers`
- [ ] Khi cloud-config được cập nhật cho production, giá trị `application.cors.allowed-origins` từ config-repo sẽ override (cùng key, dev profile chỉ là fallback)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GQyQPQxSfiMNgmttpttc3W)_