### PR TITLE
chore: remove cloud-config, inline config to local yaml

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -34,10 +34,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-gateway-server-webflux</artifactId>
         </dependency>
         <dependency>

--- a/api-gateway/src/main/resources/application-dev.yml
+++ b/api-gateway/src/main/resources/application-dev.yml
@@ -1,8 +1,73 @@
+server:
+  port: 8072
+
 spring:
-  config:
-    import: optional:configserver:http://localhost:8888/
-    activate:
-      on-profile: dev
+  data:
+    redis:
+      connect-timeout: 2s
+      host: localhost
+      port: 6379
+      timeout: 1s
+  cloud:
+    gateway:
+      discovery:
+        locator:
+          enabled: true
+          lowerCaseServiceId: true
+      httpclient:
+        connect-timeout: 1000
+        response-timeout: 10s
+      routes:
+        - id: auth-service
+          uri: lb://auth-service
+          predicates:
+            - Path=/api/v1/auth/**
+          filters:
+            - name: Authentication
+              args:
+                publicEndpoints:
+                  - "/api/v1/auth/register"
+                  - "/api/v1/auth/login"
+                  - "/api/v1/auth/refresh-token"
+                  - "/api/v1/auth/verify-otp"
+                  - "/api/v1/auth/forgot-password"
+                  - "/api/v1/auth/reset-password"
+            - name: RequestRateLimiter
+              args:
+                redis-rate-limiter.replenishRate: 10
+                redis-rate-limiter.burstCapacity: 20
+                key-resolver: "#{@userEmailOrIpKeyResolver}"
+        - id: user-service
+          uri: lb://user-service
+          predicates:
+            - Path=/v1/api/users/**, /v1/api/internal/users/**, /v1/api/admin/users/**
+          filters:
+            - name: ApiKey
+              args:
+                keys:
+                  "admin-secret-key": "admin"
+                  "internal-secret-key": "internal"
+                  "public-secret-key": "public"
+            - name: Authentication
+              args:
+                publicEndpoints: []
+            - CircuitBreaker=user-service-cb
+        - id: movie-service
+          uri: lb://movie-service
+          predicates:
+            - Path=/v1/api/movies/**, /v1/api/internal/movies/**
+          filters:
+            - name: ApiKey
+              args:
+                keys:
+                  "admin-secret-key": "admin"
+                  "internal-secret-key": "internal"
+            - name: Authentication
+              args:
+                publicEndpoints:
+                  - "/v1/api/movies/public/**"
+            - CircuitBreaker=movie-service-cb
+
 rsa:
   public:
     key-location: classpath:certs/public.pem
@@ -13,11 +78,45 @@ auth:
     audience: novaplay
     kid: v1
 
-# Local-dev fallback for CORS. Production values come from cloud-config.
-# Override in cloud-config/application.yml when adding new frontend origins.
 application:
   cors:
     allowed-origins:
       - http://localhost:5173
       - http://localhost:3000
       - http://127.0.0.1:5173
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    gateway:
+      access: unrestricted
+  info:
+    env:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+logging:
+  level:
+    vn:
+      iotstar:
+        apigateway: DEBUG
+    org:
+      springframework:
+        cloud:
+          gateway: INFO
+  pattern:
+    level: "%5p [${spring.application.name},%X{traceId},%X{spanId}]"
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        slidingWindowSize: 10
+        permittedNumberOfCallsInHalfOpenState: 2
+        failureRateThreshold: 50
+        waitDurationInOpenState: 10000

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -1,5 +1,3 @@
 spring:
   application:
     name: api-gateway
-  profiles:
-    active: dev

--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -25,10 +25,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
         <dependency>
@@ -74,10 +70,6 @@
             <artifactId>springdoc-openapi-starter-common</artifactId>
             <version>2.8.8</version>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-bus-kafka</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.kafka</groupId>

--- a/auth-service/src/main/resources/application-dev.yml
+++ b/auth-service/src/main/resources/application-dev.yml
@@ -1,17 +1,60 @@
+server:
+  port: 8000
+
 spring:
-  config:
-    import: optional:configserver:http://localhost:8888/
-    activate:
-      on-profile: dev
+  datasource:
+    url: jdbc:postgresql://localhost:5432/auth_service
+    username: admin
+    password: admin123
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 5s
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      retries: 10
+      delivery-timeout-ms: 120000
+      enable-idempotence: true
+      linger-ms: 10
+      batch-size: 32768
+      properties:
+        max.in.flight.requests.per.connection: 5
+        compression.type: lz4
+  application:
+    security:
+      jwt:
+        expiration: 86400000
+        refresh-token:
+          expiration: 604800000
+
+jwt:
+  private-key-path: classpath:keys/private.pem
+  public-key-path: classpath:keys/public.pem
 
 auth:
   jwt:
     issuer: novaplay-auth
     audience: novaplay
     kid: v1
-    expiration: 900000
-    refresh-token:
-      expiration: 2592000000
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
 
 management:
   endpoints:
@@ -30,4 +73,12 @@ management:
       enabled: true
   metrics:
     tags:
-      application: auth-service
+      application: ${spring.application.name}
+
+logging:
+  level:
+    vn:
+      iotstar:
+        authservice: DEBUG
+  pattern:
+    level: "%5p [${spring.application.name},%X{traceId},%X{spanId}]"

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -1,9 +1,3 @@
 spring:
   application:
     name: auth-service
-  profiles:
-    active: dev
-logging:
-  level:
-    org.springframework: DEBUG
-    org.springframework.jdbc: DEBUG


### PR DESCRIPTION
## Summary

- Xóa `spring-cloud-starter-config` khỏi `api-gateway` và `auth-service` — không còn phụ thuộc vào cloud-config server khi startup
- Xóa `spring-cloud-starter-bus-kafka` khỏi `auth-service` — chỉ dùng cho config refresh, không cần thiết nữa
- Gộp toàn bộ config từ `cloud_config_NovaPlay` repo vào local `application-dev.yml` của từng service
- Fix property name mismatch: `auth.jwt.expiration` → `spring.application.security.jwt.expiration` (match với `@Value` trong `JwtServiceImpl`)
- Xóa `spring.profiles.active: dev` hardcode khỏi base `application.yml` → profile được set qua env var `SPRING_PROFILES_ACTIVE`
- Xóa `logging.level.org.springframework: DEBUG` khỏi base `application.yml` của auth-service

## Chi tiết thay đổi

### api-gateway
| File | Thay đổi |
|---|---|
| `pom.xml` | Xóa `spring-cloud-starter-config` |
| `application.yml` | Chỉ giữ `spring.application.name` |
| `application-dev.yml` | Thêm: server port, Redis, Gateway routes, CORS, Resilience4j, logging |

### auth-service
| File | Thay đổi |
|---|---|
| `pom.xml` | Xóa `spring-cloud-starter-config` và `spring-cloud-starter-bus-kafka` |
| `application.yml` | Chỉ giữ `spring.application.name` |
| `application-dev.yml` | Thêm: server port, DB, Redis, Kafka producer config, JWT expiration (đúng property path), springdoc |

## Test plan

- [ ] `api-gateway` boot được mà không cần cloud-config server chạy
- [ ] `auth-service` boot được mà không cần cloud-config server chạy
- [ ] Login/register flow hoạt động bình thường
- [ ] JWT token được generate với expiration đúng (24h access, 7 ngày refresh)
- [ ] Rate limiter trên api-gateway hoạt động (10 req/s, burst 20)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMUQc7eBu9Rfu9bQX3SnFZ)_