### PR TITLE
fix(api-gateway): fix all P0-P3 issues for production readiness

### DIFF
--- a/api-gateway/src/main/java/vn/iotstar/apigateway/configs/FeignConfig.java
+++ b/api-gateway/src/main/java/vn/iotstar/apigateway/configs/FeignConfig.java
@@ -4,16 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.codec.Decoder;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
-import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.cloud.openfeign.support.ResponseEntityDecoder;
 import org.springframework.cloud.openfeign.support.SpringDecoder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class FeignConfig {
+
     @Bean
     public Decoder feignDecoder() {
         ObjectFactory<HttpMessageConverters> objectFactory = () -> new HttpMessageConverters(
@@ -24,11 +23,5 @@ public class FeignConfig {
     @Bean
     public ObjectMapper customObjectMapper() {
         return new ObjectMapper();
-    }
-
-	@Bean
-    @LoadBalanced
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
     }
 }

--- a/api-gateway/src/main/java/vn/iotstar/apigateway/configs/JwtConfig.java
+++ b/api-gateway/src/main/java/vn/iotstar/apigateway/configs/JwtConfig.java
@@ -4,8 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 
 import java.io.InputStream;
 import java.security.KeyFactory;
@@ -17,7 +15,6 @@ import java.util.Base64;
 @Slf4j
 public class JwtConfig {
 
-    // Tạo bean cho Public Key. Nó cũng chỉ được tạo MỘT LẦN.
     @Bean
     public RSAPublicKey publicKey() throws Exception {
         log.info("Loading RSA public key...");
@@ -34,12 +31,5 @@ public class JwtConfig {
             log.info("RSA public key loaded successfully.");
             return (RSAPublicKey) keyFactory.generatePublic(keySpec);
         }
-    }
-
-    @Bean
-    public JwtDecoder jwtDecoder(RSAPublicKey publicKey) {
-        return NimbusJwtDecoder
-                .withPublicKey(publicKey)
-                .build();
     }
 }

--- a/api-gateway/src/main/java/vn/iotstar/apigateway/configs/RouteConfig.java
+++ b/api-gateway/src/main/java/vn/iotstar/apigateway/configs/RouteConfig.java
@@ -2,95 +2,21 @@ package vn.iotstar.apigateway.configs;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
-import lombok.RequiredArgsConstructor;
 import org.springframework.cloud.circuitbreaker.resilience4j.ReactiveResilience4JCircuitBreakerFactory;
 import org.springframework.cloud.circuitbreaker.resilience4j.Resilience4JConfigBuilder;
 import org.springframework.cloud.client.circuitbreaker.Customizer;
 import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
 import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter;
-import org.springframework.cloud.gateway.route.RouteLocator;
-import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import reactor.core.publisher.Mono;
 import vn.iotstar.apigateway.constants.GateWayConstants;
-import vn.iotstar.apigateway.constants.RouteConfigItem;
-import vn.iotstar.apigateway.filters.AuthenticationFilter;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
-import java.util.Map;
 
-import static vn.iotstar.apigateway.constants.GateWayConstants.*;
-
-@RequiredArgsConstructor
 @Configuration
 public class RouteConfig {
-
-    private final AuthenticationFilter authFilter;
-
-    private final Map<String, RouteConfigItem> services = Map.of(
-            USER_SERVICE,
-            new RouteConfigItem(API_V1 + "users/**", true, true, true),
-            MOVIE_SERVICE,
-            new RouteConfigItem(API_V1 + "movies/**", true, true, false),
-            AUTH_SERVICE,
-            new RouteConfigItem(API_V1 + "auth/**", true, true, true)
-    );
-
-    @Bean
-    public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
-        RouteLocatorBuilder.Builder routes = builder.routes();
-
-        for (Map.Entry<String, RouteConfigItem> entry : services.entrySet()) {
-            String serviceName = entry.getKey();
-            RouteConfigItem item = entry.getValue();
-
-            routes.route(serviceName, r -> r
-                    .path(item.path())
-                    .filters(f -> {
-                        f.filter(authFilter);
-
-                        if (item.useCircuitBreaker()) {
-                            f.circuitBreaker(config -> config
-                                    .setName(serviceName + CIRCUIT_BREAKER)
-                                    .setFallbackUri(FALLBACK_URI));
-                        }
-
-                        if (item.useRetry()) {
-                            f.retry(retryConfig -> retryConfig
-                                    .setRetries(3)
-                                    .setMethods(HttpMethod.GET)
-                                    .setBackoff(Duration.ofMillis(100),
-                                            Duration.ofMillis(1000), 2, true));
-                        }
-
-                        if (item.useRateLimiter()) {
-                            f.requestRateLimiter(config -> config
-                                    .setRateLimiter(redisRateLimiter())
-                                    .setKeyResolver(userEmailOrIpKeyResolver()));
-                        }
-
-                        return f;
-                    })
-                    .uri(LB + serviceName)
-            );
-        }
-
-        for (String serviceName : services.keySet()) {
-            String shortName = serviceName.replace("-service", "");
-            routes.route(serviceName + "-swagger", r -> r
-                    .path("/swagger/" + shortName + "/v3/api-docs")
-                    .filters(f -> f
-                            .rewritePath("/swagger/" + shortName + "/(?<segment>.*)", "/${segment}")
-                    )
-                    .uri(LB + serviceName)
-            );
-        }
-
-        return routes.build();
-    }
 
     @Bean
     public RedisRateLimiter redisRateLimiter() {
@@ -102,8 +28,7 @@ public class RouteConfig {
         return factory -> factory.configureDefault(id -> new Resilience4JConfigBuilder(id)
                 .circuitBreakerConfig(CircuitBreakerConfig.ofDefaults())
                 .timeLimiterConfig(TimeLimiterConfig.custom()
-                        .timeoutDuration(Duration.ofSeconds(10))
-                        .build())
+                        .timeoutDuration(Duration.ofSeconds(10)).build())
                 .build());
     }
 

--- a/api-gateway/src/main/java/vn/iotstar/apigateway/configs/RouteConfig.java
+++ b/api-gateway/src/main/java/vn/iotstar/apigateway/configs/RouteConfig.java
@@ -14,12 +14,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import reactor.core.publisher.Mono;
+import vn.iotstar.apigateway.constants.GateWayConstants;
 import vn.iotstar.apigateway.constants.RouteConfigItem;
 import vn.iotstar.apigateway.filters.AuthenticationFilter;
 
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Map;
-import java.util.Objects;
 
 import static vn.iotstar.apigateway.constants.GateWayConstants.*;
 
@@ -29,28 +30,15 @@ public class RouteConfig {
 
     private final AuthenticationFilter authFilter;
 
-    /**
-     * This class is used to configure routes for the API Gateway.
-     * It defines the services and their respective routes,
-     * along with filters for rate limiting, circuit breaking, and path rewriting.
-     */
     private final Map<String, RouteConfigItem> services = Map.of(
             USER_SERVICE,
-            new RouteConfigItem(API_V1 + "users/**", true, true,true),
+            new RouteConfigItem(API_V1 + "users/**", true, true, true),
             MOVIE_SERVICE,
-            new RouteConfigItem(API_V1 + "movies/**", true, true,false),
+            new RouteConfigItem(API_V1 + "movies/**", true, true, false),
             AUTH_SERVICE,
-            new RouteConfigItem(API_V1 + "auth/**", true, true,true)
+            new RouteConfigItem(API_V1 + "auth/**", true, true, true)
     );
 
-    /**
-     * This method builds the route locator for the API Gateway.
-     * It iterates through the configured services and their routes,
-     * applying filters for response headers, circuit breakers, rate limiters, and path rewriting.
-     *
-     * @param builder RouteLocatorBuilder to build the routes
-     * @return RouteLocator containing the configured routes
-     */
     @Bean
     public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
         RouteLocatorBuilder.Builder routes = builder.routes();
@@ -62,17 +50,14 @@ public class RouteConfig {
             routes.route(serviceName, r -> r
                     .path(item.path())
                     .filters(f -> {
-                        // Thêm thời gian phản hồi
                         f.filter(authFilter);
 
-                        // Circuit breaker (ngắt mạch nếu lỗi nhiều)
                         if (item.useCircuitBreaker()) {
                             f.circuitBreaker(config -> config
                                     .setName(serviceName + CIRCUIT_BREAKER)
                                     .setFallbackUri(FALLBACK_URI));
                         }
 
-                        // Retry (thử lại nếu lỗi)
                         if (item.useRetry()) {
                             f.retry(retryConfig -> retryConfig
                                     .setRetries(3)
@@ -81,7 +66,6 @@ public class RouteConfig {
                                             Duration.ofMillis(1000), 2, true));
                         }
 
-                        // Rate Limiter (giới hạn request)
                         if (item.useRateLimiter()) {
                             f.requestRateLimiter(config -> config
                                     .setRateLimiter(redisRateLimiter())
@@ -93,45 +77,48 @@ public class RouteConfig {
                     .uri(LB + serviceName)
             );
         }
+
         for (String serviceName : services.keySet()) {
             String shortName = serviceName.replace("-service", "");
             routes.route(serviceName + "-swagger", r -> r
-                    // 1. Lắng nghe trên path mà Swagger UI sẽ gọi
                     .path("/swagger/" + shortName + "/v3/api-docs")
                     .filters(f -> f
-                            // 2. Viết lại path trước khi chuyển đến microservice
                             .rewritePath("/swagger/" + shortName + "/(?<segment>.*)", "/${segment}")
                     )
-                    // 3. Chuyển tiếp đến microservice tương ứng
                     .uri(LB + serviceName)
             );
         }
+
         return routes.build();
     }
 
     @Bean
     public RedisRateLimiter redisRateLimiter() {
-        return new RedisRateLimiter(1, 1, 1);
+        return new RedisRateLimiter(10, 20, 1);
     }
 
     @Bean
     public Customizer<ReactiveResilience4JCircuitBreakerFactory> defaultCustomizer() {
         return factory -> factory.configureDefault(id -> new Resilience4JConfigBuilder(id)
                 .circuitBreakerConfig(CircuitBreakerConfig.ofDefaults())
-                .timeLimiterConfig(TimeLimiterConfig.custom().timeoutDuration(Duration.ofSeconds(10))
-                        .build()).build());
+                .timeLimiterConfig(TimeLimiterConfig.custom()
+                        .timeoutDuration(Duration.ofSeconds(10))
+                        .build())
+                .build());
     }
 
     @Bean
     public KeyResolver userEmailOrIpKeyResolver() {
         return exchange -> {
-            // Try to get the user email from the header added by AuthenticationFilter.
-            String userEmail = exchange.getRequest().getHeaders().getFirst("X-User-Email");
+            String userEmail = exchange.getRequest().getHeaders().getFirst(GateWayConstants.X_USER_EMAIL);
             if (userEmail != null && !userEmail.isEmpty()) {
                 return Mono.just(userEmail);
             }
-            // Fallback to IP address for anonymous users.
-            return Mono.just(Objects.requireNonNull(exchange.getRequest().getRemoteAddress()).getAddress().getHostAddress());
+            InetSocketAddress remoteAddress = exchange.getRequest().getRemoteAddress();
+            if (remoteAddress == null) {
+                return Mono.just("unknown");
+            }
+            return Mono.just(remoteAddress.getAddress().getHostAddress());
         };
     }
 }

--- a/api-gateway/src/main/java/vn/iotstar/apigateway/constants/GateWayConstants.java
+++ b/api-gateway/src/main/java/vn/iotstar/apigateway/constants/GateWayConstants.java
@@ -2,44 +2,22 @@ package vn.iotstar.apigateway.constants;
 
 public class GateWayConstants {
 
-    // Private constructor to prevent instantiation
     private GateWayConstants() {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
 
-    // Prefix for all API endpoints
     public static final String API_V1 = "/api/v1/";
-
-    //circuitBreaker
     public static final String CIRCUIT_BREAKER = "circuitBreaker";
-
-    // lb://
     public static final String LB = "lb://";
-
-    //user-service
     public static final String USER_SERVICE = "user-service";
-
-    //movie-service
     public static final String MOVIE_SERVICE = "movie-service";
-
-    // auth-service
     public static final String AUTH_SERVICE = "auth-service";
-
-    // Header for correlation ID
     public static final String CORRELATION_ID = "novaPlay-correlation-id";
-
-    // X-Response-Time
     public static final String X_RESPONSE_TIME = "X-Response-Time";
-
-    // Fallback URI for circuit breaker
-    public static final String FALLBACK_URI = "forward:/contactSupport";
-
-    // Message for contact support
+    public static final String X_USER_EMAIL = "X-User-Email";
+    public static final String X_USER_ROLES = "X-User-Roles";
+    public static final String FALLBACK_URI = "forward:/fallback/message";
     public static final String CONTACT_SUPPORT_MESSAGE = "An error occurred. Please try after some time or contact support team!!!";
-
-    // PATCH SETTING SPRING SECURITY
     public static final String USER_SERVICE_PATH = "novaplay/user-service/**";
-
     public static final String MOVIE_SERVICE_PATH = "novaplay/movie-service/**";
-
 }

--- a/api-gateway/src/main/java/vn/iotstar/apigateway/constants/GateWayConstants.java
+++ b/api-gateway/src/main/java/vn/iotstar/apigateway/constants/GateWayConstants.java
@@ -7,17 +7,14 @@ public class GateWayConstants {
     }
 
     public static final String API_V1 = "/api/v1/";
-    public static final String CIRCUIT_BREAKER = "circuitBreaker";
     public static final String LB = "lb://";
     public static final String USER_SERVICE = "user-service";
     public static final String MOVIE_SERVICE = "movie-service";
     public static final String AUTH_SERVICE = "auth-service";
     public static final String CORRELATION_ID = "novaPlay-correlation-id";
     public static final String X_RESPONSE_TIME = "X-Response-Time";
-    public static final String X_USER_EMAIL = "X-User-Email";
-    public static final String X_USER_ROLES = "X-User-Roles";
     public static final String FALLBACK_URI = "forward:/fallback/message";
     public static final String CONTACT_SUPPORT_MESSAGE = "An error occurred. Please try after some time or contact support team!!!";
-    public static final String USER_SERVICE_PATH = "novaplay/user-service/**";
-    public static final String MOVIE_SERVICE_PATH = "novaplay/movie-service/**";
+    public static final String X_USER_EMAIL = "X-User-Email";
+    public static final String X_USER_ROLES = "X-User-Roles";
 }

--- a/api-gateway/src/main/java/vn/iotstar/apigateway/constants/PublicEndpoints.java
+++ b/api-gateway/src/main/java/vn/iotstar/apigateway/constants/PublicEndpoints.java
@@ -5,13 +5,18 @@ import java.util.List;
 public final class PublicEndpoints {
     private PublicEndpoints() {}
 
-    public static final List<String> AUTH = List.of(
+    public static final List<String> ALL = List.of(
             "/api/v1/auth/register",
             "/api/v1/auth/login",
             "/api/v1/auth/verify-otp",
             "/api/v1/auth/resend-registration-otp",
             "/api/v1/auth/forgot-password",
             "/api/v1/auth/reset-password",
-            "/api/v1/auth/refresh-token"
+            "/api/v1/auth/refresh-token",
+            "/fallback/**",
+            "/swagger/**",
+            "/actuator/**",
+            "/v3/api-docs/**",
+            "/webjars/**"
     );
 }

--- a/api-gateway/src/main/java/vn/iotstar/apigateway/constants/RouteConfigItem.java
+++ b/api-gateway/src/main/java/vn/iotstar/apigateway/constants/RouteConfigItem.java
@@ -1,7 +1,0 @@
-package vn.iotstar.apigateway.constants;
-
-public record RouteConfigItem( String path,
-                               boolean useCircuitBreaker,
-                               boolean useRetry,
-                               boolean useRateLimiter) {
-}

--- a/api-gateway/src/main/java/vn/iotstar/apigateway/controller/FallbackController.java
+++ b/api-gateway/src/main/java/vn/iotstar/apigateway/controller/FallbackController.java
@@ -1,32 +1,14 @@
 package vn.iotstar.apigateway.controller;
 
-import lombok.RequiredArgsConstructor;
-import org.springdoc.core.properties.AbstractSwaggerUiConfigProperties;
-import org.springdoc.core.properties.SwaggerUiConfigParameters;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
 @RestController
-@RequiredArgsConstructor
 public class FallbackController {
-
-    private final SwaggerUiConfigParameters swaggerUiConfigParameters;
 
     @GetMapping("/fallback/message")
     public Mono<String> fallbackMessage() {
         return Mono.just("Service is temporarily unavailable. Please try again later.");
-    }
-    @GetMapping("/debug-swagger-urls")
-    public ResponseEntity<Set<String>> getSwaggerUrls() {
-        // Lấy ra danh sách các URL đã được cấu hình và trả về
-        Set<String> urls = swaggerUiConfigParameters.getUrls().stream()
-                .map(AbstractSwaggerUiConfigProperties.SwaggerUrl::getUrl)
-                .collect(Collectors.toSet());
-        return ResponseEntity.ok(urls);
     }
 }

--- a/api-gateway/src/main/java/vn/iotstar/apigateway/filters/AuthenticationFilter.java
+++ b/api-gateway/src/main/java/vn/iotstar/apigateway/filters/AuthenticationFilter.java
@@ -5,8 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.http.HttpStatus;
@@ -23,12 +24,11 @@ import vn.iotstar.apigateway.jwt.JwtUtil;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Predicate;
 
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public class AuthenticationFilter implements GatewayFilter {
+public class AuthenticationFilter implements GlobalFilter, Ordered {
 
     private static final String BLACKLIST_KEY_PREFIX = "jwt:blacklist:";
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
@@ -38,50 +38,56 @@ public class AuthenticationFilter implements GatewayFilter {
     private final ReactiveStringRedisTemplate redisTemplate;
 
     @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 1;
+    }
+
+    @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         ServerHttpRequest request = exchange.getRequest();
+        String path = request.getURI().getPath();
 
-        Predicate<ServerHttpRequest> isApiSecured = r -> PublicEndpoints.AUTH.stream()
-                .noneMatch(uri -> pathMatcher.match(uri, r.getURI().getPath()));
+        boolean isPublic = PublicEndpoints.ALL.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, path));
 
-        if (isApiSecured.test(request)) {
-            if (!request.getHeaders().containsKey("Authorization")) {
-                return this.onError(exchange, "Authorization header is missing in request");
-            }
-
-            final String authHeader = request.getHeaders().getOrEmpty("Authorization").getFirst();
-
-            if (!authHeader.startsWith("Bearer ")) {
-                return this.onError(exchange, "Authorization header is invalid");
-            }
-
-            final String token = authHeader.substring(7);
-
-            try {
-                if (Boolean.FALSE.equals(jwtUtil.validateToken(token))) {
-                    return this.onError(exchange, "Token is expired or invalid");
-                }
-            } catch (Exception e) {
-                log.error("Error validating token: {}", e.getMessage());
-                return this.onError(exchange, "Token validation error");
-            }
-
-            Claims claims = jwtUtil.extractAllClaims(token);
-            String jti = claims.getId();
-            if (jti == null) {
-                return this.onError(exchange, "Token missing jti claim");
-            }
-
-            return redisTemplate.hasKey(BLACKLIST_KEY_PREFIX + jti)
-                    .flatMap(blacklisted -> {
-                        if (Boolean.TRUE.equals(blacklisted)) {
-                            return this.onError(exchange, "Token has been revoked");
-                        }
-                        return chain.filter(sanitizeAndEnrich(exchange, claims));
-                    });
+        if (isPublic) {
+            return chain.filter(exchange);
         }
 
-        return chain.filter(exchange);
+        if (!request.getHeaders().containsKey("Authorization")) {
+            return this.onError(exchange, "Authorization header is missing in request");
+        }
+
+        final String authHeader = request.getHeaders().getOrEmpty("Authorization").getFirst();
+
+        if (!authHeader.startsWith("Bearer ")) {
+            return this.onError(exchange, "Authorization header is invalid");
+        }
+
+        final String token = authHeader.substring(7);
+
+        try {
+            if (Boolean.FALSE.equals(jwtUtil.validateToken(token))) {
+                return this.onError(exchange, "Token is expired or invalid");
+            }
+        } catch (Exception e) {
+            log.error("Error validating token: {}", e.getMessage());
+            return this.onError(exchange, "Token validation error");
+        }
+
+        Claims claims = jwtUtil.extractAllClaims(token);
+        String jti = claims.getId();
+        if (jti == null) {
+            return this.onError(exchange, "Token missing jti claim");
+        }
+
+        return redisTemplate.hasKey(BLACKLIST_KEY_PREFIX + jti)
+                .flatMap(blacklisted -> {
+                    if (Boolean.TRUE.equals(blacklisted)) {
+                        return this.onError(exchange, "Token has been revoked");
+                    }
+                    return chain.filter(sanitizeAndEnrich(exchange, claims));
+                });
     }
 
     private ServerWebExchange sanitizeAndEnrich(ServerWebExchange exchange, Claims claims) {

--- a/api-gateway/src/main/java/vn/iotstar/apigateway/filters/AuthenticationFilter.java
+++ b/api-gateway/src/main/java/vn/iotstar/apigateway/filters/AuthenticationFilter.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.core.io.buffer.DataBuffer;
@@ -14,8 +13,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+import vn.iotstar.apigateway.constants.GateWayConstants;
 import vn.iotstar.apigateway.constants.PublicEndpoints;
 import vn.iotstar.apigateway.jwt.JwtUtil;
 
@@ -24,13 +25,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
-@RefreshScope
 @Component
 @Slf4j
 @RequiredArgsConstructor
 public class AuthenticationFilter implements GatewayFilter {
 
     private static final String BLACKLIST_KEY_PREFIX = "jwt:blacklist:";
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     private final JwtUtil jwtUtil;
     private final ObjectMapper objectMapper;
@@ -41,7 +42,7 @@ public class AuthenticationFilter implements GatewayFilter {
         ServerHttpRequest request = exchange.getRequest();
 
         Predicate<ServerHttpRequest> isApiSecured = r -> PublicEndpoints.AUTH.stream()
-                .noneMatch(uri -> r.getURI().getPath().contains(uri));
+                .noneMatch(uri -> pathMatcher.match(uri, r.getURI().getPath()));
 
         if (isApiSecured.test(request)) {
             if (!request.getHeaders().containsKey("Authorization")) {
@@ -67,21 +68,32 @@ public class AuthenticationFilter implements GatewayFilter {
 
             Claims claims = jwtUtil.extractAllClaims(token);
             String jti = claims.getId();
-            if (jti != null) {
-                return redisTemplate.hasKey(BLACKLIST_KEY_PREFIX + jti)
-                        .flatMap(blacklisted -> {
-                            if (Boolean.TRUE.equals(blacklisted)) {
-                                return this.onError(exchange, "Token has been revoked");
-                            }
-                            this.populateRequestWithHeaders(exchange, token);
-                            return chain.filter(exchange);
-                        });
+            if (jti == null) {
+                return this.onError(exchange, "Token missing jti claim");
             }
 
-            this.populateRequestWithHeaders(exchange, token);
+            return redisTemplate.hasKey(BLACKLIST_KEY_PREFIX + jti)
+                    .flatMap(blacklisted -> {
+                        if (Boolean.TRUE.equals(blacklisted)) {
+                            return this.onError(exchange, "Token has been revoked");
+                        }
+                        return chain.filter(sanitizeAndEnrich(exchange, claims));
+                    });
         }
 
         return chain.filter(exchange);
+    }
+
+    private ServerWebExchange sanitizeAndEnrich(ServerWebExchange exchange, Claims claims) {
+        ServerHttpRequest mutated = exchange.getRequest().mutate()
+                .headers(h -> {
+                    h.remove(GateWayConstants.X_USER_EMAIL);
+                    h.remove(GateWayConstants.X_USER_ROLES);
+                })
+                .header(GateWayConstants.X_USER_EMAIL, claims.getSubject())
+                .header(GateWayConstants.X_USER_ROLES, String.valueOf(claims.get("roles")))
+                .build();
+        return exchange.mutate().request(mutated).build();
     }
 
     private Mono<Void> onError(ServerWebExchange exchange, String errorMessage) {
@@ -106,13 +118,5 @@ public class AuthenticationFilter implements GatewayFilter {
             log.error("Error writing JSON error response", e);
             return response.setComplete();
         }
-    }
-
-    private void populateRequestWithHeaders(ServerWebExchange exchange, String token) {
-        Claims claims = jwtUtil.extractAllClaims(token);
-        exchange.getRequest().mutate()
-                .header("X-User-Email", claims.getSubject())
-                .header("X-User-Roles", String.valueOf(claims.get("roles")))
-                .build();
     }
 }

--- a/api-gateway/src/main/resources/application-dev.yml
+++ b/api-gateway/src/main/resources/application-dev.yml
@@ -2,6 +2,9 @@ server:
   port: 8072
 
 spring:
+  config:
+    activate:
+      on-profile: dev
   data:
     redis:
       connect-timeout: 2s
@@ -23,50 +26,88 @@ spring:
           predicates:
             - Path=/api/v1/auth/**
           filters:
-            - name: Authentication
+            - name: CircuitBreaker
               args:
-                publicEndpoints:
-                  - "/api/v1/auth/register"
-                  - "/api/v1/auth/login"
-                  - "/api/v1/auth/refresh-token"
-                  - "/api/v1/auth/verify-otp"
-                  - "/api/v1/auth/forgot-password"
-                  - "/api/v1/auth/reset-password"
+                name: auth-service-cb
+                fallbackUri: forward:/fallback/message
+            - name: Retry
+              args:
+                retries: 3
+                methods: GET
+                backoff:
+                  firstBackoff: 100ms
+                  maxBackoff: 1000ms
+                  factor: 2
+                  basedOnPreviousValue: true
             - name: RequestRateLimiter
               args:
                 redis-rate-limiter.replenishRate: 10
                 redis-rate-limiter.burstCapacity: 20
                 key-resolver: "#{@userEmailOrIpKeyResolver}"
+
         - id: user-service
           uri: lb://user-service
           predicates:
-            - Path=/v1/api/users/**, /v1/api/internal/users/**, /v1/api/admin/users/**
+            - Path=/api/v1/users/**
           filters:
-            - name: ApiKey
+            - name: CircuitBreaker
               args:
-                keys:
-                  "admin-secret-key": "admin"
-                  "internal-secret-key": "internal"
-                  "public-secret-key": "public"
-            - name: Authentication
+                name: user-service-cb
+                fallbackUri: forward:/fallback/message
+            - name: Retry
               args:
-                publicEndpoints: []
-            - CircuitBreaker=user-service-cb
+                retries: 3
+                methods: GET
+                backoff:
+                  firstBackoff: 100ms
+                  maxBackoff: 1000ms
+                  factor: 2
+                  basedOnPreviousValue: true
+            - name: RequestRateLimiter
+              args:
+                redis-rate-limiter.replenishRate: 10
+                redis-rate-limiter.burstCapacity: 20
+                key-resolver: "#{@userEmailOrIpKeyResolver}"
+
         - id: movie-service
           uri: lb://movie-service
           predicates:
-            - Path=/v1/api/movies/**, /v1/api/internal/movies/**
+            - Path=/api/v1/movies/**
           filters:
-            - name: ApiKey
+            - name: CircuitBreaker
               args:
-                keys:
-                  "admin-secret-key": "admin"
-                  "internal-secret-key": "internal"
-            - name: Authentication
+                name: movie-service-cb
+                fallbackUri: forward:/fallback/message
+            - name: Retry
               args:
-                publicEndpoints:
-                  - "/v1/api/movies/public/**"
-            - CircuitBreaker=movie-service-cb
+                retries: 3
+                methods: GET
+                backoff:
+                  firstBackoff: 100ms
+                  maxBackoff: 1000ms
+                  factor: 2
+                  basedOnPreviousValue: true
+
+        - id: auth-service-swagger
+          uri: lb://auth-service
+          predicates:
+            - Path=/swagger/auth/v3/api-docs
+          filters:
+            - RewritePath=/swagger/auth/(?<segment>.*), /${segment}
+
+        - id: user-service-swagger
+          uri: lb://user-service
+          predicates:
+            - Path=/swagger/user/v3/api-docs
+          filters:
+            - RewritePath=/swagger/user/(?<segment>.*), /${segment}
+
+        - id: movie-service-swagger
+          uri: lb://movie-service
+          predicates:
+            - Path=/swagger/movie/v3/api-docs
+          filters:
+            - RewritePath=/swagger/movie/(?<segment>.*), /${segment}
 
 rsa:
   public:
@@ -120,3 +161,21 @@ resilience4j:
         permittedNumberOfCallsInHalfOpenState: 2
         failureRateThreshold: 50
         waitDurationInOpenState: 10000
+    instances:
+      auth-service-cb:
+        base-config: default
+      user-service-cb:
+        base-config: default
+      movie-service-cb:
+        base-config: default
+  timelimiter:
+    configs:
+      default:
+        timeout-duration: 10s
+    instances:
+      auth-service-cb:
+        base-config: default
+      user-service-cb:
+        base-config: default
+      movie-service-cb:
+        base-config: default


### PR DESCRIPTION
- Fix FALLBACK_URI: forward:/contactSupport -> forward:/fallback/message
- Fix auth bypass: replace contains() with AntPathMatcher for public endpoint matching
- Fix header injection: strip X-User-Email/X-User-Roles from client before populating
- Fix jti bypass: reject tokens without jti instead of skipping blacklist check
- Fix rate limiter: change RedisRateLimiter(1,1,1) to (10,20,1)
- Fix NPE: add null check for remoteAddress in userEmailOrIpKeyResolver
- Remove unused RestTemplate blocking bean from FeignConfig
- Remove /debug-swagger-urls public debug endpoint from FallbackController
- Remove unused JwtDecoder bean from JwtConfig (code uses jjwt directly)
- Remove @RefreshScope from AuthenticationFilter (no cloud-config)