### PR TITLE
Fix failing unit tests in notification-service and movie-service CI

### DIFF
--- a/movie-service/src/test/java/vn/iotstar/movieservice/repository/MovieRepositoryIT.java
+++ b/movie-service/src/test/java/vn/iotstar/movieservice/repository/MovieRepositoryIT.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.testcontainers.DockerClientFactory;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -16,6 +17,7 @@ import org.springframework.data.mongodb.core.index.TextIndexDefinition;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import vn.iotstar.movieservice.config.security.MongoAuditingConfig;
 import vn.iotstar.movieservice.model.entity.Movie;
 import vn.iotstar.movieservice.model.entity.embedded.CastMember;
 import vn.iotstar.movieservice.model.entity.embedded.GenreRef;
@@ -38,6 +40,10 @@ import static vn.iotstar.movieservice.utils.Constants.*;
  */
 @Testcontainers
 @DataMongoTest
+// @DataMongoTest chỉ scan repository/document, không kéo theo @Configuration của ứng dụng —
+// thiếu import này thì auditorAware không được đăng ký, @EnableMongoAuditing không kích hoạt,
+// và @CreatedDate/@CreatedBy im lặng bị bỏ qua dù @Version đã đúng.
+@Import(MongoAuditingConfig.class)
 @EnabledIf("dockerAvailable")
 class MovieRepositoryIT {
 

--- a/notification-service/src/test/java/vn/iotstar/notificationservice/service/impl/MailSenderImplTest.java
+++ b/notification-service/src/test/java/vn/iotstar/notificationservice/service/impl/MailSenderImplTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class MailSenderImplTest {
 
     private static final String FRONTEND = "https://novaplay.test";
+    private static final String MAIL_FROM = "no-reply@novaplay.test";
 
     private AtomicReference<MimeMessage> sent;
     private MailSenderImpl mailSender;
@@ -85,6 +87,9 @@ class MailSenderImplTest {
         templateEngine.setTemplateEngineMessageSource(messageSource);
 
         var metrics = new NotificationMetrics(new SimpleMeterRegistry());
+        mailSender = new MailSenderImpl(javaMailSender, templateEngine, messageSource, metrics);
+        ReflectionTestUtils.setField(mailSender, "mailFrom", MAIL_FROM);
+        ReflectionTestUtils.setField(mailSender, "frontendBaseUrl", FRONTEND);
     }
 
     private static NotificationRequest otpRequest(Locale locale) {
@@ -164,6 +169,14 @@ class MailSenderImplTest {
         var registry = new SimpleMeterRegistry();
         var failing = new RecordingMailSender(new AtomicReference<>());
         failing.failWith(new MailSendException("boom"));
+
+        var failingSender = new MailSenderImpl(failing, templateEngine, messageSource,
+                new NotificationMetrics(registry));
+        ReflectionTestUtils.setField(failingSender, "mailFrom", MAIL_FROM);
+        ReflectionTestUtils.setField(failingSender, "frontendBaseUrl", FRONTEND);
+
+        assertThatThrownBy(() -> failingSender.send(otpRequest(Locale.forLanguageTag("vi-VN"))))
+                .isInstanceOf(MailDeliveryException.class);
 
         Timer timer = registry.find("notification.email.send").timer();
         assertThat(timer).isNotNull();


### PR DESCRIPTION
notification-service: MailSenderImplTest never constructed the
MailSenderImpl under test, leaving mailSender null and causing NPEs in
6 of 7 tests. Wire it up in setUp() with mailFrom/frontendBaseUrl set
via ReflectionTestUtils (mirrors the @Value fields Spring injects at
runtime), and complete timer_luon_duoc_dung so it actually exercises a
failing send instead of asserting on an untouched registry.

movie-service: MovieRepositoryIT (@DataMongoTest) never imported
MongoAuditingConfig, so @EnableMongoAuditing was never active in that
slice and @CreatedDate/@CreatedBy were silently skipped regardless of
the @Version field, failing
auditingPopulatesCreatedAtDespitePreAssignedId. Import the config
explicitly, consistent with how it's kept off the main application
class to avoid breaking @WebMvcTest slices.