### PR TITLE
Fix remaining notification-service integration test failures

### DIFF
--- a/notification-service/src/test/java/vn/iotstar/notificationservice/channel/MailDeliveryIT.java
+++ b/notification-service/src/test/java/vn/iotstar/notificationservice/channel/MailDeliveryIT.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
@@ -38,6 +39,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class MailDeliveryIT {
 
+    private static final String FRONTEND = "https://novaplay.test";
+    private static final String MAIL_FROM = "no-reply@novaplay.test";
+
     @RegisterExtension
     static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP);
 
@@ -62,6 +66,12 @@ class MailDeliveryIT {
         var engine = new SpringTemplateEngine();
         engine.setTemplateResolver(resolver);
         engine.setTemplateEngineMessageSource(messageSource);
+
+        var mailSender = new MailSenderImpl(javaMailSender, engine, messageSource,
+                new NotificationMetrics(new SimpleMeterRegistry()));
+        ReflectionTestUtils.setField(mailSender, "mailFrom", MAIL_FROM);
+        ReflectionTestUtils.setField(mailSender, "frontendBaseUrl", FRONTEND);
+        channel = new EmailChannel(mailSender);
     }
 
     private static NotificationRequest otp(Locale locale) {
@@ -126,6 +136,14 @@ class MailDeliveryIT {
         engine.setTemplateResolver(resolver);
         engine.setTemplateEngineMessageSource(messageSource);
 
+        var deadMailSender = new MailSenderImpl(deadSender, engine, messageSource,
+                new NotificationMetrics(new SimpleMeterRegistry()));
+        ReflectionTestUtils.setField(deadMailSender, "mailFrom", MAIL_FROM);
+        ReflectionTestUtils.setField(deadMailSender, "frontendBaseUrl", FRONTEND);
+        var deadChannel = new EmailChannel(deadMailSender);
+
+        assertThatThrownBy(() -> deadChannel.send(otp(Locale.forLanguageTag("vi-VN"))))
+                .isInstanceOf(MailDeliveryException.class);
 
         // Thất bại ở tầng transport nghĩa là thư chưa rời đi — dispatcher được phép thử lại.
         assertThat(greenMail.getReceivedMessages()).isEmpty();

--- a/notification-service/src/test/java/vn/iotstar/notificationservice/repository/NotificationRepositoryIT.java
+++ b/notification-service/src/test/java/vn/iotstar/notificationservice/repository/NotificationRepositoryIT.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -18,6 +19,7 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import vn.iotstar.notificationservice.config.MongoIndexInitializer;
+import vn.iotstar.notificationservice.config.security.MongoAuditingConfig;
 import vn.iotstar.notificationservice.model.entity.Notification;
 import vn.iotstar.notificationservice.model.enums.NotificationType;
 
@@ -39,6 +41,10 @@ import static vn.iotstar.notificationservice.util.Constants.*;
  */
 @Testcontainers
 @DataMongoTest
+// @DataMongoTest chỉ scan repository/document, không kéo theo @Configuration của ứng dụng —
+// thiếu import này thì auditorAware không được đăng ký, @EnableMongoAuditing không kích hoạt,
+// và @CreatedDate im lặng bị bỏ qua dù @Version đã đúng.
+@Import(MongoAuditingConfig.class)
 @EnabledIf("dockerAvailable")
 class NotificationRepositoryIT {
 


### PR DESCRIPTION
These were latent: the earlier unit-test failures stopped the Maven
build before failsafe ever ran, so CI never got far enough to surface
them.

MailDeliveryIT: setUp() built javaMailSender/messageSource/engine but
never assigned the EmailChannel field under test, so every test threw
NPE on channel.send(...). Wire the channel from a real MailSenderImpl,
and complete smtp_khong_toi_duoc so it actually sends through the dead
SMTP host and asserts MailDeliveryException instead of trivially
checking an inbox nothing was ever sent to.

NotificationRepositoryIT: same gap as movie-service's MovieRepositoryIT
— @DataMongoTest doesn't pull in the app's MongoAuditingConfig, so
@EnableMongoAuditing was never active and created_at_duoc_dien failed
despite Notification already having @Version. Import the config
explicitly.